### PR TITLE
Update gt-letterhead.sty

### DIFF
--- a/gt-letterhead.sty
+++ b/gt-letterhead.sty
@@ -151,6 +151,7 @@
     \end{textblock*}
     \vspace{0.3in}
     \color{GTblue}
+
     \fontsize{8}{12}\robotoMedium{\@fromdept} \\
     \fontsize{7}{12}\plexsans{Atlanta, Georgia 30332-0700 U.S.A.} \\
     \fontsize{7}{12}\plexsans{Phone: 404.894.9044} \\


### PR DESCRIPTION
Fixes layout issue with department name placed right onto `foot.png`.