### PR TITLE
Add ability to comment out \toaddress to omit.

### DIFF
--- a/gt-letterhead.sty
+++ b/gt-letterhead.sty
@@ -63,7 +63,7 @@
 \DeclareRobustCommand{\fromname}[1]{\DeclareRobustCommand\@fromname{#1 \\}}
 \DeclareRobustCommand{\fromemail}[1]{\DeclareRobustCommand\@fromemail{#1 \\}}
 \DeclareRobustCommand{\fromweb}[1]{\DeclareRobustCommand\@fromweb{#1}}
-\DeclareRobustCommand{\toaddress}[1]{\DeclareRobustCommand\@toaddress{#1}}
+\newcommand{\toaddress}[1]{\def\@toaddress{#1}}
 \DeclareRobustCommand{\closing}[1]{\DeclareRobustCommand\@closing{#1}}
 \newcommand{\signaturefile}[1]{\def\@signaturefile{#1}}
 \newcommand{\aboutme}[1]{\def\@aboutme{#1}}
@@ -134,7 +134,7 @@
 
 \AtBeginDocument{%
     \vspace*{-0.25in}
-    \@toaddress \\
+    \ifthenelse{\equal{\@toaddress}{}}{}{{\@toaddress \\}}
     \hfill\@fromdate
 }
 

--- a/template.tex
+++ b/template.tex
@@ -6,7 +6,7 @@
 % footer
 \fromdept{College of Computing}
 
-\toaddress{Example Optional \\ To/From Address \\ Can Go Here}
+\toaddress{Example Optional \\ To/From Address \\ Or Can Comment Out}
 
 % header
 \fromdate{October 1, 2021}


### PR DESCRIPTION
This PR adds the ability to comment out \toaddress in the main letter body and simply omit the entry from the header fully. Currently, commenting out that directive or filled it with whitespace results in an error. This mimics the same structure as \aboutme which has the desired comment -> omit functionality.

(Look professor remembered how github PR's work.)